### PR TITLE
fix DownloadFileAsync for ModNet download

### DIFF
--- a/GameLauncher/App/MainScreen.cs
+++ b/GameLauncher/App/MainScreen.cs
@@ -2170,10 +2170,10 @@ namespace GameLauncher {
 
                 ModNetFileNameInUse = FileName;
 
-                FileDownloader client2 = new FileDownloader();
+                WebClientWithTimeout client2 = new WebClientWithTimeout();
 
-                client2.ProgressChanged += new DownloadProgressHandler(client_DownloadProgressChanged_RELOADED);
-                client2.DownloadComplete += (test, stuff) => {
+                client2.DownloadProgressChanged += new DownloadProgressChangedEventHandler(client_DownloadProgressChanged_RELOADED);
+                client2.DownloadFileCompleted += (test, stuff) => {
                     Log.Debug("Downloaded: " + FileName);
                     isDownloadingModNetFiles = false;
                     if (modFilesDownloadUrls.Any() == false) {
@@ -2183,7 +2183,7 @@ namespace GameLauncher {
                         DownloadModNetFilesRightNow(path);
                     }
                 };
-                client2.Download(url.ToString(), path);
+                client2.DownloadFileAsync(url, path + "/" + FileName);
                 isDownloadingModNetFiles = true;
             }
         }
@@ -2241,23 +2241,23 @@ namespace GameLauncher {
             }
         }
 
-        void client_DownloadProgressChanged_RELOADED(object sender, DownloadEventArgs e) {
-            //this.BeginInvoke((MethodInvoker)delegate {
-                double bytesIn = double.Parse(e.CurrentFileSize.ToString());
-                double totalBytes = double.Parse(e.TotalFileSize.ToString());
-                double percentage = bytesIn / totalBytes * 100;
+        void client_DownloadProgressChanged_RELOADED(object sender, DownloadProgressChangedEventArgs e)
+        {
+            this.BeginInvoke((MethodInvoker)delegate {
+                double bytesIn = double.Parse(e.BytesReceived.ToString());
+                double totalBytes = double.Parse(e.TotalBytesToReceive.ToString());
 
-                playProgressText.Text = ("Downloading " + ModNetFileNameInUse + ": " + FormatFileSize(e.CurrentFileSize) + " of " + FormatFileSize(e.TotalFileSize)).ToUpper();
+                playProgressText.Text = ("Downloading " + ModNetFileNameInUse + ": " + FormatFileSize(e.BytesReceived) + " of " + FormatFileSize(e.TotalBytesToReceive)).ToUpper();
                 playProgressText2.Text = "[ "+CurrentModFileCount+" / "+TotalModFileCount+" ]";
 
-                extractingProgress.Value = Convert.ToInt32(Decimal.Divide(e.CurrentFileSize, e.TotalFileSize) * 100);
-                extractingProgress.Width = Convert.ToInt32(Decimal.Divide(e.CurrentFileSize, e.TotalFileSize) * 519);
+                extractingProgress.Value = Convert.ToInt32(Decimal.Divide(e.BytesReceived, e.TotalBytesToReceive) * 100);
+                extractingProgress.Width = Convert.ToInt32(Decimal.Divide(e.BytesReceived, e.TotalBytesToReceive) * 519);
 
-                playProgress.Value = Convert.ToInt32(Decimal.Divide(e.CurrentFileSize, e.TotalFileSize) * 100);
-                playProgress.Width = Convert.ToInt32(Decimal.Divide(e.CurrentFileSize, e.TotalFileSize) * 519);
+                playProgress.Value = Convert.ToInt32(Decimal.Divide(e.BytesReceived, e.TotalBytesToReceive) * 100);
+                playProgress.Width = Convert.ToInt32(Decimal.Divide(e.BytesReceived, e.TotalBytesToReceive) * 519);
 
                 Application.DoEvents();
-            //});
+            });
         }
 
         //Launch game


### PR DESCRIPTION
The launcher wasn't able to replace existing mods with [21faf8d30c4bc7a92906eb9eb66b6acab955bc9f](https://github.com/SoapboxRaceWorld/GameLauncher_NFSW/commit/21faf8d30c4bc7a92906eb9eb66b6acab955bc9f)
so i fixed the old DownloadFileAsync who was missing a FileName after the path.
The launcher correctly replaced two mod files that i edited manually and the game started without errors.
