### PR TITLE
Adding Fallback Static CDN List Support

### DIFF
--- a/GameLauncher/App/Classes/Self.cs
+++ b/GameLauncher/App/Classes/Self.cs
@@ -17,16 +17,19 @@ namespace GameLauncherReborn {
     class Self {
         public static string mainserver = "https://api.worldunited.gg";
         public static string fileserver = "https://files.worldunited.gg";
+        public static string staticapiserver = "http://api-sbrw.davidcarbon.download";
 
         public static string[] serverlisturl = new string[] {
             mainserver + "/serverlist.json",
-            "http://api-sbrw.davidcarbon.download/serverlist.json",
+            staticapiserver + "/serverlist.json"
         }; 
 
 		public static string statsurl = mainserver + "/stats";
         public static string CDNUrlList = mainserver + "/cdn_list.json";
+        public static string CDNUrlStaticList = staticapiserver + "/cdn_list.json";
 
-		private static IniFile SettingFile = new IniFile("Settings.ini");
+
+        private static IniFile SettingFile = new IniFile("Settings.ini");
 
         public static string DiscordRPCID = "540651192179752970";
 

--- a/GameLauncher/App/MainScreen.cs
+++ b/GameLauncher/App/MainScreen.cs
@@ -663,11 +663,17 @@ namespace GameLauncher {
                 String _slresponse2 = string.Empty;
                 try {
                     WebClientWithTimeout wc = new WebClientWithTimeout();
-                    _slresponse2 = wc.DownloadString(Self.CDNUrlList);
+                    try {
+                       _slresponse2 = wc.DownloadString(Self.CDNUrlList);
+                    }
+                    catch {
+                       _slresponse2 = wc.DownloadString(Self.CDNUrlStaticList);
+                    }
+
                 } catch(Exception error) {
-                    MessageBox.Show(error.Message, "An error occurred while loading CDN List");
+                    MessageBox.Show(error.Message, "An error occurred while loading CDN Lists");
                     _slresponse2 = JsonConvert.SerializeObject(new[] {
-                        new CDNObject { name = "[CF] WorldUnited.gg Mirror", url = "http://cdn.worldunited.gg/gamefiles/packed/" }
+                        new CDNObject { name = "[PL] WorldUnited.gg Mirror", url = "http://cdn.worldunited.gg/gamefiles/packed/" }
                     });
                 }
 

--- a/GameLauncher/App/WelcomeScreen.cs
+++ b/GameLauncher/App/WelcomeScreen.cs
@@ -27,7 +27,15 @@ namespace GameLauncher.App {
             String _slresponse = String.Empty;
             try {
                 WebClientWithTimeout wc = new WebClientWithTimeout();
-                _slresponse = wc.DownloadString(Self.CDNUrlList);
+                try
+                {
+                   _slresponse = wc.DownloadString(Self.CDNUrlList);
+                }
+                catch
+                {
+                   _slresponse = wc.DownloadString(Self.CDNUrlStaticList);
+                }
+                
             } catch {
                 _slresponse = JsonConvert.SerializeObject(new[] {
                     new CDNObject {

--- a/GameLauncher/Program.cs
+++ b/GameLauncher/Program.cs
@@ -98,8 +98,19 @@ namespace GameLauncher {
                         String _slresponse = wc3.DownloadString(Self.CDNUrlList);
                         CDNList = JsonConvert.DeserializeObject<List<CDNObject>>(_slresponse);
                         _settingFile.Write("CDN", CDNList.First().url);
-                    } catch {
-                        _settingFile.Write("CDN", "http://cdn.worldunited.gg/gamefiles/packed/");
+                    }
+                    catch {
+                        try {
+                            List<CDNObject> CDNList = new List<CDNObject>();
+                            WebClientWithTimeout wc3 = new WebClientWithTimeout();
+                            String _slresponse = wc3.DownloadString(Self.CDNUrlStaticList);
+                            CDNList = JsonConvert.DeserializeObject<List<CDNObject>>(_slresponse);
+                            _settingFile.Write("CDN", CDNList.First().url);
+                        }
+                        catch
+                        {
+                            _settingFile.Write("CDN", "http://cdn.worldunited.gg/gamefiles/packed/");
+                        }
                     }
                 }
             }

--- a/GameLauncher/Properties/AssemblyInfo.cs
+++ b/GameLauncher/Properties/AssemblyInfo.cs
@@ -14,5 +14,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("0a114c5c-3566-4a62-b05d-cba311988d8a")]
 
-[assembly: AssemblyVersion("2.1.6.1")]
-[assembly: AssemblyFileVersion("2.1.6.1")]
+[assembly: AssemblyVersion("2.1.6.2")]
+[assembly: AssemblyFileVersion("2.1.6.2")]


### PR DESCRIPTION
I've included a try function to attempt to get the CDN list from the backup static api, if the main api fails to load. If both lists fail to load it will then fall back to WorldUnited.gg CDN (Hard coded).

Program.cs Lines: 102-114
```
                    catch {
                        try {
                            List<CDNObject> CDNList = new List<CDNObject>();
                            WebClientWithTimeout wc3 = new WebClientWithTimeout();
                            String _slresponse = wc3.DownloadString(Self.CDNUrlStaticList);
                            CDNList = JsonConvert.DeserializeObject<List<CDNObject>>(_slresponse);
                            _settingFile.Write("CDN", CDNList.First().url);
                        }
                        catch
                        {
                            _settingFile.Write("CDN", "http://cdn.worldunited.gg/gamefiles/packed/");
                        }
                    }
```

I've also changed the following in Self.cs, MainScreen.cs, WelcomeScreen.cs for the fall back cdn list (so it displays correctly)
```
                    try {
                       _slresponse2 = wc.DownloadString(Self.CDNUrlList);
                    }
                    catch {
                       _slresponse2 = wc.DownloadString(Self.CDNUrlStaticList);
                    }
```