### PR TITLE
Replace DotNetZip with System.IO.Compression.ZipFile

### DIFF
--- a/GameLauncher/GameLauncher.csproj
+++ b/GameLauncher/GameLauncher.csproj
@@ -90,9 +90,6 @@
     <Reference Include="DiscordRPC, Version=1.0.150.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DiscordRichPresence.1.0.150\lib\net35\DiscordRPC.dll</HintPath>
     </Reference>
-    <Reference Include="DotNetZip, Version=1.15.0.0, Culture=neutral, PublicKeyToken=6583c7c814667745, processorArchitecture=MSIL">
-      <HintPath>..\packages\DotNetZip.1.15.0\lib\net40\DotNetZip.dll</HintPath>
-    </Reference>
     <Reference Include="Flurl, Version=2.8.2.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Flurl.2.8.2\lib\net40\Flurl.dll</HintPath>
     </Reference>

--- a/GameLauncher/Program.cs
+++ b/GameLauncher/Program.cs
@@ -266,7 +266,7 @@ namespace GameLauncher {
                         wc.DownloadFileAsync(new Uri(Self.fileserver + "/LZMA.dll"), "LZMA.dll");
                     }
 
-                    DialogResult restartApp = MessageBox.Show(null, "Downloaded Missing LZMA.ddl File. \nPlease Restart Launcher, Thanks!", "GameLauncher Restart Required", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
+                    DialogResult restartApp = MessageBox.Show(null, "Downloaded Missing LZMA.dll File. \nPlease Restart Launcher, Thanks!", "GameLauncher Restart Required", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
 
                     if (restartApp == DialogResult.Yes)
                     {

--- a/GameLauncher/Properties/AssemblyInfo.cs
+++ b/GameLauncher/Properties/AssemblyInfo.cs
@@ -15,6 +15,6 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("0a114c5c-3566-4a62-b05d-cba311988d8a")]
 
-[assembly: AssemblyVersion("2.1.6.6")]
-[assembly: AssemblyFileVersion("2.1.6.6")]
+[assembly: AssemblyVersion("2.1.6.7")]
+[assembly: AssemblyFileVersion("2.1.6.7")]
 [assembly: NeutralResourcesLanguage("en-US")]

--- a/GameLauncher/packages.config
+++ b/GameLauncher/packages.config
@@ -2,7 +2,6 @@
 <packages>
   <package id="CommandLineParser" version="2.8.0" targetFramework="net46" />
   <package id="DiscordRichPresence" version="1.0.150" targetFramework="net46" />
-  <package id="DotNetZip" version="1.15.0" targetFramework="net46" />
   <package id="Flurl" version="2.8.2" targetFramework="net46" />
   <package id="Flurl.Http" version="2.4.2" targetFramework="net46" />
   <package id="ini-parser" version="2.5.2" targetFramework="net40" />


### PR DESCRIPTION
As you already know, `DotNetZip` is actually being flagged by antiviruses. This pull request should fix that issue by using built in System.IO.Compression.ZipFile function, which is by default already preinstalled.