### PR TITLE
Fixes SoapboxRaceWorld/GameLauncher_NFSW#262

### DIFF
--- a/SBRW.Launcher.Net/App/UI_Forms/Main_Screen/Screen_Main.cs
+++ b/SBRW.Launcher.Net/App/UI_Forms/Main_Screen/Screen_Main.cs
@@ -982,6 +982,16 @@ namespace SBRW.Launcher.App.UI_Forms.Main_Screen
             {
                 Presence_Launcher.Start(false, Presence_Launcher.ApplicationID());
 
+                /* Reset Sever Mods File Download Count (Visual Only) */
+                CurrentModFileCount = 0;
+                TotalModFileCount = 0;
+
+                if (ModFilesDownloadUrls != default)
+                {
+                    /* If Server Mod List is not Empty, Empty it just in case */
+                    ModFilesDownloadUrls.Clear();
+                }
+
                 try
                 {
                     if (UI_MODE != 12)

--- a/SBRW.Launcher.Net/SBRW.Launcher.csproj
+++ b/SBRW.Launcher.Net/SBRW.Launcher.csproj
@@ -19,7 +19,7 @@
 	You can specify this option only for projects that target .NET Framework 4.5 or later.
     <PlatformTarget>x86</PlatformTarget>-->
     <Copyright>© Soapbox Race World</Copyright>
-    <GlobalVersion>2.2.2</GlobalVersion>
+    <GlobalVersion>2.2.3</GlobalVersion>
     <GlobalVersion Condition=" '$(GlobalVersion)' == '' ">2.2.0.$([System.DateTime]::UtcNow.ToString(mmff))</GlobalVersion>
     <Version>$(GlobalVersion)</Version>
     <AssemblyVersion>$(GlobalVersion)</AssemblyVersion>

--- a/SBRW.Launcher.RunTime/InsiderKit/KitEnabler.cs
+++ b/SBRW.Launcher.RunTime/InsiderKit/KitEnabler.cs
@@ -9,7 +9,7 @@ namespace SBRW.Launcher.RunTime.InsiderKit
         /* Current month, day, year (2 digits), and letter! Ex: 12-15-20-A */
         /* If a second build gets release within the same day bump letter version up (No R2 or D2)*/
 
-        private static string InsiderBuildNumber { get; set; } = "05-18-23-C";
+        private static string InsiderBuildNumber { get; set; } = "10-31-23-A";
 
         public static string BuildNumberOnly()
         {


### PR DESCRIPTION
Fixed:
- Server Mods File Download Count would fail to display correctly if the game crashed and returned to the login screen. In turn switching to another server and redownloading switched server mods